### PR TITLE
Fix invalid toml boolean for optional dependency

### DIFF
--- a/src/cargo-fuzz/structure-aware-fuzzing.md
+++ b/src/cargo-fuzz/structure-aware-fuzzing.md
@@ -47,7 +47,7 @@ conversion crate, we add this to our main `Cargo.toml`.
 # Cargo.toml
 
 [dependencies]
-arbitrary = { version = "0.3.0", optional = "true", features = ["derive"] }
+arbitrary = { version = "0.3.0", optional = true, features = ["derive"] }
 ```
 
 ### Derive `Arbitrary` for our `Rgb` Type


### PR DESCRIPTION
The optional field for dependencies should be a boolean, else cargo can't parse this line