### PR TITLE
Setup: mention Apple Silicon support.

### DIFF
--- a/src/cargo-fuzz/setup.md
+++ b/src/cargo-fuzz/setup.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-libFuzzer needs LLVM sanitizer support, so this only works on x86-64 Linux and x86-64 macOS for now. This also needs a nightly compiler since it uses some unstable command-line flags. You'll also need a C++ compiler with C++11 support.
+libFuzzer needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS and Apple-Silicon (aarch64) macOS for now. This also needs a nightly compiler since it uses some unstable command-line flags. You'll also need a C++ compiler with C++11 support.
 
 ## Installing
 


### PR DESCRIPTION
I just noticed that the setup info is not accurate anymore.

According to [this](https://github.com/rust-fuzz/cargo-fuzz/pull/244) M1 support has been available for a while.