### PR TITLE
Add information on how to switch compilers

### DIFF
--- a/src/cargo-fuzz/setup.md
+++ b/src/cargo-fuzz/setup.md
@@ -2,7 +2,20 @@
 
 ## Requirements
 
-libFuzzer needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS and Apple-Silicon (aarch64) macOS for now. This also needs a nightly compiler since it uses some unstable command-line flags. You'll also need a C++ compiler with C++11 support.
+libFuzzer needs LLVM sanitizer support, so this only works on x86-64 Linux, x86-64 macOS and Apple-Silicon (aarch64) macOS for now. Requires a C++ compiler with C++11 support. Rust provides multiple compilers. This project requires the nightly compiler since it uses the `-Z` compiler flag to provide address sanitization. Assuming you used [rustup][rustup] to install Rust, you can check your default compiler with:
+
+```shell
+$ rustup default
+stable-x86_64-unknown-linux-gnu (default) # Not the compiler we want.
+```
+
+To change to the nightly compiler:
+
+```shell
+$ rustup install nightly
+$ rustup default nightly
+nightly-x86_64-unknown-linux-gnu (default) # The correct compiler.
+```
 
 ## Installing
 
@@ -15,3 +28,5 @@ cargo install cargo-fuzz
 ```sh
 cargo install --force cargo-fuzz
 ```
+
+[rustup]: https://github.com/rust-lang/rustup


### PR DESCRIPTION
The requirements were vague on the experimental compiler flags. The proposed pull request provides a concrete reason for needing the nightly build, as well as information on how to install it and make it the default compiler. This documentations makes it easier for new Rustaceans to build their first harness.