### PR TITLE
Update afl setup with cargo-afl

### DIFF
--- a/src/afl/setup.md
+++ b/src/afl/setup.md
@@ -12,11 +12,11 @@
 afl.rs works on x86-64 Linux, x86-64 macOS, and ARM64 macOS.
 
 ```sh
-cargo install afl
+cargo install cargo-afl
 ```
 
 ## Upgrading
 
 ```sh
-cargo install --force afl
+cargo install --force cargo-afl
 ```


### PR DESCRIPTION
https://github.com/rust-fuzz/afl.rs requires you to install afl with `cargo install cargo-afl` instead of just `cargo install afl`. This just changes the commands