### PR TITLE
Update guide.md (fix typo in fuzzing_repro section)

### DIFF
--- a/src/cargo-fuzz/guide.md
+++ b/src/cargo-fuzz/guide.md
@@ -28,7 +28,7 @@ Every crate instrumented for fuzzing -- the `fuzz_targets` crate, the project cr
 
 ## `#[cfg(fuzzing_repro)]`
 
-When you run `cargo fuzz <fuzz target name> <crash file>`, every crate is compiled with the `--cfg fuzzing_repro` rustc option. This allows you to leave debugging statements in your fuzz targets behind a `#[cfg(fuzzing_repro)]`:
+When you run `cargo fuzz run <fuzz target name> <crash file>`, every crate is compiled with the `--cfg fuzzing_repro` rustc option. This allows you to leave debugging statements in your fuzz targets behind a `#[cfg(fuzzing_repro)]`:
 
 ```rust
 #[cfg(fuzzing_repro)]


### PR DESCRIPTION
This commit fixes the command indicated in the fuzzing_repro section.