### PR TITLE
Remove mentions of `fuzzing_repro`

### DIFF
--- a/src/cargo-fuzz/guide.md
+++ b/src/cargo-fuzz/guide.md
@@ -26,15 +26,6 @@ unsafe = ["project/unsafe"]
 
 Every crate instrumented for fuzzing -- the `fuzz_targets` crate, the project crate, and their entire dependency tree -- is compiled with the `--cfg fuzzing` rustc option. This makes it possible to disable code paths that prevent fuzzing from working, e.g. verification of cryptographic signatures, with a simple `#[cfg(not(fuzzing))]`, and without the need for an externally visible Cargo feature that must be maintained throughout every dependency.
 
-## `#[cfg(fuzzing_repro)]`
-
-When you run `cargo fuzz run <fuzz target name> <crash file>`, every crate is compiled with the `--cfg fuzzing_repro` rustc option. This allows you to leave debugging statements in your fuzz targets behind a `#[cfg(fuzzing_repro)]`:
-
-```rust
-#[cfg(fuzzing_repro)]
-eprintln!("Input data: {}", expensive_pretty_print(&data));
-```
-
 ## libFuzzer configuration options
 
 See all the libFuzzer options:


### PR DESCRIPTION
Since that functionality was reverted in https://github.com/rust-fuzz/cargo-fuzz/pull/362