### PR TITLE
Update AFL tutorial to use `url` version having a bug

### DIFF
--- a/src/afl/tutorial.md
+++ b/src/afl/tutorial.md
@@ -21,8 +21,10 @@ So add these to the `Cargo.toml` file:
 ```toml
 [dependencies]
 afl = "*"
-url = "*"
+url = { git = "https://github.com/servo/rust-url.git", rev = "bfa167b4e0253642b6766a7aa74a99df60a94048" }
 ```
+
+We chose a particular revision of `url` that is known to have a bug. Your goal is to find it!
 
 Now we’ll need to write the source for the fuzz target in `src/main.rs`:
 


### PR DESCRIPTION
With `url = "*"` I didn't hit a bug in three days of CPU time, and I didn't know if that's because I had followed the tutorial incorrectly. With the proposed change to use revision bfa167b4e0253642b6766a7aa74a99df60a94048 I find a bug in four seconds. Note that the cargo-fuzz tutorial points to this revision but that is in a parallel section, not an outer setup chapter, so it seems reasonable and expedient to just duplicate.