### PR TITLE
clarify that afl fuzz inputs are necessary and link to how to craft them

### DIFF
--- a/src/afl/tutorial.md
+++ b/src/afl/tutorial.md
@@ -69,7 +69,11 @@ cargo afl build
 
 ## Provide starting inputs
 
-AFL doesn't strictly require starting inputs, but providing some can make AFL’s job easier since it won’t need to ‘learn’ what a valid URL looks like. To do this, we'll create a directory called `in` with a few files (filenames don’t matter) containing valid URLs:
+AFL strictly requires starting inputs, and will not execute at all without being provided an input directory containing at least one example input. A high-quality input corpus contains many different examples of valid inputs which exercise different features of the parsing process being fuzzed. Further instruction on crafting an effective input corpus is available in the [AFL README], including discussion of the dictionary approach for highly verbose data formats such as HTML.
+
+For this tutorial, we won't be generating a high-quality corpus, but just enough to demonstrate the basic mechanism. To do this, we'll create a directory called `in` with a few files containing valid URLs:
+
+[AFL README]: https://lcamtuf.coredump.cx/afl/README.txt
 
 ```sh
 mkdir in
@@ -88,7 +92,9 @@ cargo afl fuzz -i in -o out target/debug/url-fuzz-target
 
 The `fuzz` subcommand of `cargo-afl` is the primary interface for fuzzing Rust code with AFL. For those already familiar with AFL, the `fuzz` subcommand of `cargo-afl` is identical to running `afl-fuzz`.
 
-The `-i` flag specifies a directory full of input files AFL will use as seeds.
+The `-i` flag specifies a directory containing input files AFL will use as seeds.
+
+Inputs can be filtered by their file extension with the `-e ext` flag.
 
 The `-o` flag specifies a directory AFL will write all its state and results to.
 

--- a/src/afl/tutorial.md
+++ b/src/afl/tutorial.md
@@ -67,6 +67,8 @@ Since we want to build this crate, we’ll run:
 cargo afl build
 ```
 
+Like `cargo fuzz`, `cargo afl build` will provide the arguments `--cfg fuzzing` to build each crate in the dependency graph, which will enable any code paths annotated with `#[cfg(fuzzing)]`.
+
 ## Provide starting inputs
 
 AFL strictly requires starting inputs, and will not execute at all without being provided an input directory containing at least one example input. A high-quality input corpus contains many different examples of valid inputs which exercise different features of the parsing process being fuzzed. Further instruction on crafting an effective input corpus is available in the [AFL README], including discussion of the dictionary approach for highly verbose data formats such as HTML.


### PR DESCRIPTION
# Problem

- The book states that example inputs to AFL are not strictly required, which seems to be flatly false. I was not immediately able to identify any version of AFL which allows an empty set of input files, and the command line itself will refuse to start at all without providing a valid input directory with `-i`.
    - This is *incredibly* confusing, and the crate I'm contributing to has had a completely nonfunctional fuzz command line for months under the impression that they were doing it right somehow.
- The book goes on to state that "filenames don't matter" for input examples. This is a bit of a strange phrasing given that AFL (at least the version `afl-fuzz++4.33c` I have installed) does provide a `-e ext` flag that allows filtering inputs by file extension.
- Finally, there is no link to the afl README, which describes how to craft effective input examples, and would have allowed users to figure out for themselves that this docbook's statement about input examples not being strictly required was outdated and/or false.

# Solution
- Provide a brief description of what AFL requires from input examples.
- Mention the `-e ext` flag.
- Link to the AFL README, and mention dictionaries for more complex input.
- Clarify that `#[cfg(fuzzing)]` is enabled for `cargo afl build` as well.