### PR TITLE
add edit links to pages 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install `mdbook`
-        run: curl -L "https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz" \
+        run: curl -L "https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz" \
           | tar xvz
       - run: ./mdbook test
       - run: ./mdbook build
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install `mdbook`
-        run: curl -L "https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz" \
+        run: curl -L "https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz" \
           | tar xvz
       - run: ./mdbook build
       - run: ./ci/deploy.sh

--- a/book.toml
+++ b/book.toml
@@ -4,4 +4,7 @@ description = "Guide on how to fuzz test software written in the Rust programmin
 authors = ["Corey Farwell"]
 
 [output.html]
+git-repository-url = "https://github.com/rust-fuzz/book"
+git-repository-icon = "fab-github"
 edit-url-template = "https://github.com/rust-fuzz/book/edit/master/{path}"
+site-url = "/book/"

--- a/book.toml
+++ b/book.toml
@@ -2,3 +2,6 @@
 title = "Rust Fuzz Book"
 description = "Guide on how to fuzz test software written in the Rust programming language"
 authors = ["Corey Farwell"]
+
+[output.html]
+edit-url-template = "https://github.com/rust-fuzz/book/edit/master/{path}"


### PR DESCRIPTION
Hey, assuming you like little PRs like my typo fix in #55, I'd suggest turning on the edit icon/link.

This also updates the mdbook version used in CI to the latest since 0.4.7 didn't seem to support generating that link. And I threw in a couple other config params that I think should probably be there. The `git-repository-url`/`git-repository-icon` also adds another icon linking directly to the repo.

If you don't want these changes for any reason, feel free to just close.